### PR TITLE
Add Initial Continuous Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: go
+before_install:
+  - go get github.com/modocache/gover
+script:
+  - go test -v ./...
+  # Collect coverage reports
+  - go list -f '{{if len .TestGoFiles}}"go test -coverprofile={{.Dir}}/.coverprofile {{.ImportPath}}"{{end}}' ./... | xargs -i sh -c {}
+  # Merge coverage reports
+  - gover . coverprofile.txt
+after_success:
+  # Send coverage reports to Codecov
+  - bash < (curl -s https://codecov.io/bash) -f coverprofile.txt

--- a/uuid.go
+++ b/uuid.go
@@ -1,0 +1,2 @@
+// Package uuid produces UUIDs
+package uuid

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -1,0 +1,5 @@
+package uuid
+
+import "testing"
+
+func TestNothing(t *testing.T) {}


### PR DESCRIPTION
## Problem

The project does not automatically confirm the quality of the codebase.
## Solution

Add a Travis CI configuration yaml file which will trigger builds. This configuration includes coverage profiles so test coverage can be maintained through out the projects life.
