### PR TITLE
UUID String Formatting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ go:
   - 1.5
   - 1.6
 script:
-  - go test -coverprofile=coverage.txt -covermode=atomic
+  - go test -coverprofile=coverage.txt -covermode=atomic ./...
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/uuid.go
+++ b/uuid.go
@@ -1,2 +1,30 @@
-// Package uuid produces UUIDs
+// Package uuid is a simple library for generating RFC4122 compliant universally unique
+// identifiers.
 package uuid
+
+import "fmt"
+
+const (
+	stringFormat = "%8x-%4x-%4x-%4x-%12x"
+)
+
+// A UUID is a unique identifier.
+type UUID []byte
+
+// String provides a string representation of a UUID using the established
+// dashed format.
+func (id UUID) String() string {
+	bs := []byte(id)
+	return fmt.Sprintf(stringFormat, bs[0:4], bs[4:6], bs[6:8], bs[8:10], bs[10:])
+}
+
+// Parse returns a UUID from a given string
+func Parse(id string) (uuid UUID, err error) {
+	var a, b, c, d, e []byte
+
+	_, err = fmt.Sscanf(id, stringFormat, &a, &b, &c, &d, &e)
+
+	uuid = append(append(append(append(a, b...), c...), d...), e...)
+
+	return uuid, err
+}

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -1,5 +1,61 @@
 package uuid
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+)
 
-func TestNothing(t *testing.T) {}
+func TestUUIDString(t *testing.T) {
+	cases := []struct {
+		uuid     UUID
+		expected string
+	}{
+		{
+			[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			"00000000-0000-0000-0000-000000000000",
+		},
+		{
+			[]byte{248, 29, 79, 174, 125, 236, 17, 208, 167, 101, 0, 160, 201, 30, 107, 246},
+			"f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+		},
+	}
+
+	for _, c := range cases {
+		got := c.uuid.String()
+
+		if got != c.expected {
+			t.Errorf("Expected %+v bytes to return %s; got %s", []byte(c.uuid), c.expected, got)
+		}
+	}
+}
+
+func TestUUIDParse(t *testing.T) {
+	cases := []struct {
+		err      error
+		expected UUID
+		uuid     string
+	}{
+		{
+			nil,
+			[]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			"00000000-0000-0000-0000-000000000000",
+		},
+		{
+			nil,
+			[]byte{248, 29, 79, 174, 125, 236, 17, 208, 167, 101, 0, 160, 201, 30, 107, 246},
+			"f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
+		},
+	}
+
+	for _, c := range cases {
+		got, err := Parse(c.uuid)
+
+		if err != c.err {
+			t.Errorf("Expected %s error when parsing; got %s", c.err, err)
+		}
+
+		if !bytes.Equal(got, c.expected) {
+			t.Errorf("Expected %s string to return:\n want:%+v\n  got:%+v", c.uuid, []byte(c.expected), []byte(got))
+		}
+	}
+}


### PR DESCRIPTION
## Problem

There is no mechanism to produce the formatted string or parse an UUID from a properly formatted string.
## Solution

The UUID type implements the Stringer interface allowing it to be formatted as a string. The Parse function will return a UUID type.
