### PR TITLE
Add Generator Interface

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -1,0 +1,43 @@
+package uuid
+
+import (
+	"errors"
+	"io"
+)
+
+var (
+	errUnknownVersion = errors.New("Unknown version")
+)
+
+// A Version identifies how the generator generates UUIDs
+type Version int8
+
+// A Generator is a factory for creating new UUIDs
+type Generator struct {
+	writer  io.Writer
+	Version Version
+}
+
+// NewGenerator creates a new  UUID generator configured for the given version.
+func NewGenerator(version Version) (g *Generator, err error) {
+
+	// TODO: Implement version based writers
+	switch version {
+	}
+
+	return nil, errUnknownVersion
+}
+
+// Generate produces a new UUID that reflects the configuration of the
+// generator.
+func (g *Generator) Generate() UUID {
+	bs := make([]byte, 16)
+
+	g.writer.Write(bs)
+
+	// Apply flags
+	bs[6] = byte(g.Version<<4) | (0x0f & bs[6])
+	bs[8] = 0xBF & (0x80 | bs[8])
+
+	return bs
+}

--- a/generator_test.go
+++ b/generator_test.go
@@ -1,0 +1,95 @@
+package uuid
+
+import "testing"
+
+type testWriter struct{ wasWritten bool }
+
+func (w *testWriter) Write(buf []byte) (int, error) {
+	w.wasWritten = true
+
+	return 16, nil
+}
+
+type byteWriter struct {
+	index int
+	done  bool
+	count uint8
+}
+
+func (w *byteWriter) Write(buf []byte) (int, error) {
+
+	if w.count == 0xff {
+		w.done = true
+		return 0, nil
+	}
+
+	buf[w.index] = byte(w.count)
+	w.count += 1
+
+	return 16, nil
+}
+
+func testGeneratorFactory(version Version) *Generator {
+	return &Generator{&testWriter{}, version}
+}
+
+func byteWriterGeneratorFactory(index int, version Version) (*Generator, *byteWriter) {
+	w := &byteWriter{index, false, 0}
+	gen := &Generator{w, version}
+
+	return gen, w
+}
+
+func TestNewGeneratorInvalidVersion(t *testing.T) {
+	g, err := NewGenerator(-1)
+
+	if err != errUnknownVersion {
+		t.Errorf("Expected error %s with version %d; got %s", errUnknownVersion, -1, err)
+	}
+
+	if g != nil {
+		t.Errorf("Expected invalid version to return a nil generator")
+	}
+}
+
+func TestGeneratorVariant(t *testing.T) {
+	gen, w := byteWriterGeneratorFactory(8, 0)
+
+	for !w.done {
+		uuid := gen.Generate()
+
+		varaint := uuid[8] & 0xC0
+
+		if varaint != byte(0x80) {
+			t.Errorf("Expected any value of varaint field to begin with 0x04; Got %x", varaint)
+		}
+
+	}
+}
+
+func TestGeneratorVersion(t *testing.T) {
+	versions := []Version{1, 2, 3, 4, 5}
+
+	for _, version := range versions {
+
+		gen, w := byteWriterGeneratorFactory(6, version)
+
+		for !w.done {
+			uuid := gen.Generate()
+
+			got := uuid.Version()
+
+			if got != version {
+				t.Errorf("Expected any value of version field to equal generator version %d; Got %d", version, got)
+			}
+		}
+	}
+}
+
+func BenchmarkGeneratorGenerate(b *testing.B) {
+	gen := testGeneratorFactory(1)
+
+	for i := 0; i < b.N; i++ {
+		gen.Generate()
+	}
+}

--- a/uuid.go
+++ b/uuid.go
@@ -28,3 +28,6 @@ func Parse(id string) (uuid UUID, err error) {
 
 	return uuid, err
 }
+
+// Version of the UUID
+func (id UUID) Version() Version { return Version((id[6] & 0xF0) >> 4) }

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -59,3 +59,30 @@ func TestUUIDParse(t *testing.T) {
 		}
 	}
 }
+
+func TestUUIDVersion(t *testing.T) {
+	cases := []struct {
+		uuid    string
+		version Version
+	}{
+		{"342ce962-286b-11e6-b67b-9e71128cae77", 1},
+		{"a1322ba2-939d-2c50-91f9-7f1b6465941f", 2},
+		{"d0021c5b-595b-362b-ac92-0ac7f3faf74f", 3},
+		{"75c02ed9-f82f-4c68-91a9-9b0b6c2dd698", 4},
+		{"031ea7d5-c569-5d37-b6c2-9d1a58a96316", 5},
+	}
+
+	for _, c := range cases {
+		uuid, err := Parse(c.uuid)
+
+		if err != nil {
+			t.Errorf("Did not expect error %s when parsing test case UUID", err)
+		}
+
+		got := uuid.Version()
+
+		if got != c.version {
+			t.Errorf("Expected %s to have version %d; Got %d", c.uuid, c.version, got)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

All versions of UUIDs share a common set of bit flags. A general interface is necessary to to consistently produce flagged UUIDs.
## Solution

A generator uses a private writer to fill the byte array with the appropriate bytes for a given version. The generator then applies all bit flags and returns the new UUID.
