### PR TITLE
Add Badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ uuid
 
 > You're not a beautiful and unique snowflake, but your identifiers can be.
 
+[![Build Status](https://travis-ci.org/benjic/uuid.svg?branch=master)](https://travis-ci.org/benjic/uuid) [![codecov](https://codecov.io/gh/benjic/uuid/branch/master/graph/badge.svg)](https://codecov.io/gh/benjic/uuid) [![Go Report Card](https://goreportcard.com/badge/github.com/benjic/uuid)](https://goreportcard.com/report/github.com/benjic/uuid)
+
 As you may of guessed this library provides [RFC4122][spec] compliant
 universally unique identifiers. 
 
@@ -18,3 +20,5 @@ Goals
 - [ ] Configurable
   - If sane defaults are not ideal, a consumer should be able to configure the
     library to suit their needs.
+
+[spec]: https://tools.ietf.org/html/rfc4122


### PR DESCRIPTION
## Problem

There is no way to know if the codebase is healthy.
## Solution

Add badges to the README so consumers get a fast insight into the project.
