### PR TITLE
Add Support for Version 1 UUIDs

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -1,0 +1,12 @@
+package uuid
+
+import "net"
+
+type Version uint8
+
+// A Configuration provides sources of things.
+type Configuration struct {
+	Version      Version
+	Interfaces   []net.Interface
+	RandomReader func([]byte) (int, error)
+}

--- a/configuration.go
+++ b/configuration.go
@@ -2,6 +2,7 @@ package uuid
 
 import "net"
 
+// A Version dictates the generation of an UUID
 type Version uint8
 
 // A Configuration provides sources of things.

--- a/generator.go
+++ b/generator.go
@@ -9,20 +9,25 @@ var (
 	errUnknownVersion = errors.New("Unknown version")
 )
 
-// A Version identifies how the generator generates UUIDs
-type Version int8
-
 // A Generator is a factory for creating new UUIDs
 type Generator struct {
-	writer  io.Writer
+	reader  io.Reader
 	Version Version
 }
 
-// NewGenerator creates a new  UUID generator configured for the given version.
-func NewGenerator(version Version) (g *Generator, err error) {
+// NewGenerator creates a new  UUID generator which operates with the given
+// configuration.
+func NewGenerator(configuration Configuration) (g *Generator, err error) {
 
-	// TODO: Implement version based writers
-	switch version {
+	switch configuration.Version {
+	case 1:
+		reader, err := newV1Reader(configuration.Interfaces, configuration.RandomReader)
+
+		if err != nil {
+			return nil, err
+		}
+
+		return &Generator{reader, configuration.Version}, nil
 	}
 
 	return nil, errUnknownVersion
@@ -33,7 +38,7 @@ func NewGenerator(version Version) (g *Generator, err error) {
 func (g *Generator) Generate() UUID {
 	bs := make([]byte, 16)
 
-	g.writer.Write(bs)
+	g.reader.Read(bs)
 
 	// Apply flags
 	bs[6] = byte(g.Version<<4) | (0x0f & bs[6])

--- a/v1.go
+++ b/v1.go
@@ -1,0 +1,100 @@
+package uuid
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net"
+	"time"
+)
+
+const (
+	// Good thing calendars make sense
+	incrementsInASecond  uint64 = 1e7
+	incrementsInDay      uint64 = 60 * 60 * 24 * incrementsInASecond
+	daysUntilEpoch       uint64 = 77 + (365 * 387) + (387 / 4) - 1
+	incrementsUntilEpoch uint64 = daysUntilEpoch * incrementsInDay
+)
+
+type interfaces []net.Interface
+
+type v1Reader struct {
+	clockSequence []byte
+	node          []byte
+	timeFactory   func() []byte
+}
+
+func createTimeFactory(currentTime func() time.Time) func() []byte {
+	var last time.Time
+	var count uint64
+
+	return func() []byte {
+		buf := new(bytes.Buffer)
+
+		now := currentTime().UTC()
+		incrementsSinceEpoch := uint64(now.UnixNano() / 100)
+
+		if now.Equal(last) {
+			count++
+		}
+
+		// TODO: Make this thread safe
+		last = now
+
+		binary.Write(buf, binary.BigEndian, incrementsUntilEpoch+incrementsSinceEpoch+count)
+		return buf.Bytes()
+	}
+}
+
+func findOrDefaultNode(ifts interfaces, defaultNode func([]byte) (int, error)) (net.HardwareAddr, error) {
+
+	// Find any interface with a hardware address in the given list
+	for _, ift := range ifts {
+		if ift.HardwareAddr != nil {
+			return ift.HardwareAddr, nil
+		}
+	}
+
+	// Use a default value if no interfaces are found
+	bs := make([]byte, 6)
+	_, err := defaultNode(bs)
+
+	return bs, err
+}
+
+func newV1Reader(ifts interfaces, randomRead func([]byte) (int, error)) (*v1Reader, error) {
+
+	hardwareAddr, err := findOrDefaultNode(ifts, randomRead)
+
+	if err != nil {
+		return nil, err
+	}
+
+	timeFactory := createTimeFactory(time.Now)
+
+	clockSequence := make([]byte, 2)
+	_, err = randomRead(clockSequence)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &v1Reader{
+		clockSequence,
+		hardwareAddr,
+		timeFactory,
+	}, err
+}
+
+func (w *v1Reader) Read(bs []byte) (int, error) {
+	time := w.timeFactory()
+
+	// Rearrange the time bits
+	copy(bs[0:4], time[4:8])
+	copy(bs[4:6], time[2:4])
+	copy(bs[6:8], time[0:2])
+
+	copy(bs[8:10], w.clockSequence)
+	copy(bs[10:16], w.node)
+
+	return 16, nil
+}

--- a/v1_test.go
+++ b/v1_test.go
@@ -1,0 +1,203 @@
+package uuid
+
+import (
+	"bytes"
+	"errors"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestTimeFactoryResolution(t *testing.T) {
+	// Ensure the timeFactory will receive the timestamp
+	testTime := func() time.Time { return time.Unix(0, 0) }
+
+	tFactory := createTimeFactory(testTime)
+
+	cases := []struct {
+		timestamp []byte
+	}{
+		{[]byte{1, 178, 29, 210, 19, 129, 64, 0}},
+		{[]byte{1, 178, 29, 210, 19, 129, 64, 1}},
+		{[]byte{1, 178, 29, 210, 19, 129, 64, 2}},
+	}
+
+	for _, c := range cases {
+		bs := tFactory()
+
+		if !bytes.Equal(bs, c.timestamp) {
+			t.Error("Expected timeFactory to return incremented result if clock resolves same time")
+		}
+	}
+}
+
+func TestV1ReaderRead(t *testing.T) {
+	// Create a set of unique bytes returned by factories
+	timeFactory := func() []byte { return []byte{0, 1, 2, 3, 4, 5, 6, 7} }
+	node := []byte{10, 11, 12, 13, 14, 15}
+	clockSequence := []byte{255, 255}
+
+	testV1Reader := &v1Reader{clockSequence, node, timeFactory}
+
+	output := make([]byte, 16)
+
+	count, err := testV1Reader.Read(output)
+
+	if err != nil {
+		t.Error("Did not expect error %s", err)
+	}
+
+	if count != 16 {
+		t.Error("Read did not encounter the correct number of bytes; Wanted 16 got %d", count)
+	}
+
+	cases := []struct {
+		label    string
+		start    int
+		end      int
+		expected []byte
+	}{
+		{"timestep_low", 0, 4, []byte{4, 5, 6, 7}},
+		{"timestep_mid", 4, 6, []byte{2, 3}},
+		{"timestep_high", 6, 8, []byte{0, 1}},
+		{"clock_sequence", 8, 10, []byte{255, 255}},
+		{"node", 10, 16, []byte{10, 11, 12, 13, 14, 15}},
+	}
+
+	for _, c := range cases {
+		got := output[c.start:c.end]
+		if !bytes.Equal(got, c.expected) {
+			t.Errorf("Expected %s bytes to be %+v, got %+v", c.label, c.expected, got)
+		}
+	}
+}
+
+func TestNewV1Reader(t *testing.T) {
+	firstErr := errors.New("Failed random bytes invocation")
+	secondErr := errors.New("Failed to generate bytes for clock sequence")
+
+	failOn := func(invocation int) func([]byte) (int, error) {
+		count := 0
+		return func(bs []byte) (int, error) {
+			count++
+			switch count {
+			case 1:
+				if invocation == 1 {
+					return 0, firstErr
+				}
+
+				copy(bs, []byte{1, 1, 1, 1, 1, 1})
+				return 6, nil
+
+			case 2:
+				if invocation == 2 {
+					return 0, secondErr
+				}
+
+				copy(bs, []byte{2, 2})
+				return 2, nil
+			default:
+				panic("The failOn function should only be used once")
+			}
+		}
+	}
+
+	cases := []struct {
+		err                   error
+		expectedClockSequence []byte
+		expectedNode          []byte
+		ifts                  []net.Interface
+		randomRead            func([]byte) (int, error)
+	}{
+		{firstErr, []byte{0, 0}, []byte{0, 0, 0, 0, 0, 0}, []net.Interface{}, failOn(1)},
+		{secondErr, []byte{0, 0}, []byte{1, 1, 1, 1, 1, 1}, []net.Interface{}, failOn(2)},
+		{nil, []byte{2, 2}, []byte{1, 1, 1, 1, 1, 1}, []net.Interface{}, failOn(3)},
+	}
+
+	for _, c := range cases {
+		got, err := newV1Reader(c.ifts, c.randomRead)
+
+		if err != c.err {
+			t.Errorf("Expected error %s; got %s", c.err, err)
+		}
+
+		if got != nil {
+			if !bytes.Equal(got.clockSequence, c.expectedClockSequence) {
+				t.Errorf("Expected clockSequence %+v; got %+v", c.expectedClockSequence, got.clockSequence)
+			}
+
+			if !bytes.Equal(got.node, c.expectedNode) {
+				t.Errorf("Expected node %+v; got %+v", c.expectedNode, got.node)
+			}
+		}
+	}
+}
+
+func TestNodeValue(t *testing.T) {
+	defaultNode := func(bs []byte) (int, error) {
+		copy(bs, []byte{1, 1, 1, 1, 1, 1})
+		return 2, nil
+	}
+
+	testErr := errors.New("This is a test error")
+	errDefaultNode := func(bs []byte) (int, error) {
+		return 0, testErr
+	}
+
+	cases := []struct {
+		defaultNode func([]byte) (int, error)
+		err         error
+		expected    []byte
+		ifts        []net.Interface
+		message     string
+	}{
+		{defaultNode, nil, []byte{1, 1, 1, 1, 1, 1}, []net.Interface{}, "Expected default value %+v when interfaces is empty; got %+v"},
+		{defaultNode, nil, []byte{1, 1, 1, 1, 1, 1}, nil, "Expected default value %+v when interfaces is nil; got %+v"},
+		{
+			defaultNode,
+			nil,
+			[]byte{1, 1, 1, 1, 1, 1},
+			[]net.Interface{net.Interface{}},
+			"Expected default value %+v when interfaces have no HardwareAddr; got %+v",
+		},
+		{
+			defaultNode,
+			nil,
+			[]byte{2, 2, 2, 2, 2, 2},
+			[]net.Interface{
+				net.Interface{HardwareAddr: []byte{2, 2, 2, 2, 2, 2}},
+			},
+			"Expected hardware interface value %+v, got %+v",
+		},
+		{
+			defaultNode,
+			nil,
+			[]byte{2, 2, 2, 2, 2, 2},
+			[]net.Interface{
+				net.Interface{HardwareAddr: []byte{2, 2, 2, 2, 2, 2}},
+				net.Interface{HardwareAddr: []byte{3, 3, 3, 3, 3, 3}},
+			},
+			"Expected first hardware interface value %+v, got %+v",
+		},
+		{
+			errDefaultNode,
+			testErr,
+			[]byte{0, 0, 0, 0, 0, 0},
+			nil,
+			"Expected returned error %s; got %s",
+		},
+	}
+
+	for _, c := range cases {
+		got, err := findOrDefaultNode(c.ifts, c.defaultNode)
+
+		if err != c.err {
+			t.Errorf("Expected error %s; got %s", c.err, err)
+			break
+		}
+
+		if !bytes.Equal(got, c.expected) {
+			t.Errorf(c.message, c.expected, got)
+		}
+	}
+}


### PR DESCRIPTION
The RFC-4122 specification calls for time based UUIDs which use a combination of timestamps, clock sequence, and a node identifier.

This implementation meets the spec by using a 100 nanosecond interval timing function which deals with auto incrementing values if multiple calls resolve the so the same value. This timestamp is correctly arranged into the resulting UUID byte array.

A clock sequence is randomly generated per instance of a generator. This value is cached and written to the byte array provided by the generator.

A list of interfaces is passed into the constructor of the generator. The first Interface that has a hardware value is used and written to the byte slice of the given uuid provided by the generator.
