### PR TITLE
Add Version 4 Generator

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -28,6 +28,8 @@ func NewGenerator(configuration Configuration) (g *Generator, err error) {
 		}
 
 		return &Generator{reader, configuration.Version}, nil
+	case 4:
+		return &Generator{v4Reader{configuration.RandomReader}, configuration.Version}, nil
 	}
 
 	return nil, errUnknownVersion
@@ -39,6 +41,7 @@ func (g *Generator) Generate() UUID {
 	bs := make([]byte, 16)
 
 	g.reader.Read(bs)
+	// TODO: communicate error
 
 	// Apply flags
 	bs[6] = byte(g.Version<<4) | (0x0f & bs[6])

--- a/generator_test.go
+++ b/generator_test.go
@@ -86,7 +86,7 @@ func TestNewGeneratorFailedVersion1(t *testing.T) {
 }
 
 func TestNewGeneratorValidVersions(t *testing.T) {
-	versions := []Version{1}
+	versions := []Version{1, 4}
 
 	for _, version := range versions {
 		config := newTestConfiguration(version)

--- a/v4.go
+++ b/v4.go
@@ -1,0 +1,7 @@
+package uuid
+
+type v4Reader struct {
+	RandomReader func([]byte) (int, error)
+}
+
+func (w v4Reader) Read(bs []byte) (int, error) { return w.RandomReader(bs) }

--- a/v4_test.go
+++ b/v4_test.go
@@ -1,0 +1,41 @@
+package uuid
+
+import (
+	"net"
+	"testing"
+)
+
+type readProxy struct {
+	didCall bool
+	payload []byte
+	err     error
+}
+
+func (rp *readProxy) Read(bs []byte) (int, error) {
+	rp.didCall = true
+	copy(bs, rp.payload)
+
+	return len(bs), rp.err
+}
+
+func TestVersion4Reader(t *testing.T) {
+	rp := &readProxy{}
+	config := Configuration{
+		4,
+		[]net.Interface{},
+		rp.Read,
+	}
+
+	gen, err := NewGenerator(config)
+
+	if err != nil {
+		t.Errorf("Did not expect an error; Got %s", err)
+	}
+
+	gen.Generate()
+
+	if !rp.didCall {
+		t.Errorf("Expected generator to call underlying random proxy")
+	}
+
+}


### PR DESCRIPTION
The [spec](https://tools.ietf.org/html/rfc4122#section-4.4) calls for creating UUIDs using random numbers.

A version 4 generator populates a given byte array with random data provided by
the RandomReader property of the given configuration.
