### PR TITLE
Add Default Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,32 @@ uuid
 As you may of guessed this library provides [RFC4122][spec] compliant
 universally unique identifiers. 
 
+Example Usage
+--------------
+
+The `uuid` library provides a factory function for producing random version 4
+UUIDs. This allows you to get the identification you want with **no** setup.
+
+```go
+import (
+	"fmt"
+
+	"github.com/benjic/uuid"
+)
+
+func main() {
+	id := uuid.Generate()
+	fmt.Println(id)
+}
+```
+
 Goals
 -----
 
 - [ ] Fast
   - Benchmark should prove this library can supply a bunch of identifiers
     really, really quickly.
-- [ ] Simple
+- [x] Simple
   - If a consumer is fine with sane defaults consumption of library should be a
     simple factory function.
 - [ ] Configurable

--- a/uuid.go
+++ b/uuid.go
@@ -2,11 +2,35 @@
 // identifiers.
 package uuid
 
-import "fmt"
+import (
+	"crypto/rand"
+	"fmt"
+)
 
 const (
 	stringFormat = "%8x-%4x-%4x-%4x-%12x"
 )
+
+var defaultConfiguration Configuration = Configuration{
+	Version:      4,
+	RandomReader: rand.Read,
+}
+var defaultGenerator *Generator
+
+// Generate provides a Version 4 random UUID
+func Generate() UUID {
+	var err error
+
+	if defaultGenerator == nil {
+		defaultGenerator, err = NewGenerator(defaultConfiguration)
+
+		if err != nil {
+			panic(fmt.Sprintf("Unable to create default generator: %s", err))
+		}
+	}
+
+	return defaultGenerator.Generate()
+}
 
 // A UUID is a unique identifier.
 type UUID []byte

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -5,6 +5,34 @@ import (
 	"testing"
 )
 
+func resetDefaultGenerate() {
+	defaultGenerator = nil
+}
+
+func TestDefaultGenerator(t *testing.T) {
+	resetDefaultGenerate()
+
+	uuid := Generate()
+
+	if uuid.Version() != 4 {
+		t.Errorf("Expected a version 4 uuid from the default generator; got %d", uuid.Version())
+	}
+}
+
+func TestDefaultGeneratorPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Expected Generate to panic if defaultConfiguration is invalid")
+		}
+	}()
+
+	resetDefaultGenerate()
+	defaultConfiguration = Configuration{Version: 100}
+
+	// Attempt to generate with an invalided defualt configuration
+	Generate()
+}
+
 func TestUUIDString(t *testing.T) {
 	cases := []struct {
 		uuid     UUID


### PR DESCRIPTION
A library level factory function for UUIDs allows consumers to begin generating ids without any setup. This is ideal as most consumers would like an identifier without having to deal with boilerplate or managing a handle to a generator.
