### PR TITLE
Namespaced Generators

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -15,7 +15,7 @@ type Generator struct {
 	Version Version
 }
 
-// NewGenerator creates a new  UUID generator which operates with the given
+// NewGenerator creates a new UUID generator which operates with the given
 // configuration.
 func NewGenerator(configuration Configuration) (g *Generator, err error) {
 
@@ -38,14 +38,14 @@ func NewGenerator(configuration Configuration) (g *Generator, err error) {
 // Generate produces a new UUID that reflects the configuration of the
 // generator.
 func (g *Generator) Generate() UUID {
-	bs := make([]byte, 16)
+	uuid := make([]byte, 16)
+	g.reader.Read(uuid)
+	applyFlags(uuid, g.Version)
+	return uuid
+}
 
-	g.reader.Read(bs)
-	// TODO: communicate error
-
+func applyFlags(uuid UUID, version Version) {
 	// Apply flags
-	bs[6] = byte(g.Version<<4) | (0x0f & bs[6])
-	bs[8] = 0xBF & (0x80 | bs[8])
-
-	return bs
+	uuid[6] = byte(version<<4) | (0x0f & uuid[6])
+	uuid[8] = 0xBF & (0x80 | uuid[8])
 }

--- a/generator_test.go
+++ b/generator_test.go
@@ -28,7 +28,7 @@ func (w *byteReader) Read(buf []byte) (int, error) {
 	}
 
 	buf[w.index] = byte(w.count)
-	w.count += 1
+	w.count++
 
 	return 16, nil
 }

--- a/namespace_generator.go
+++ b/namespace_generator.go
@@ -1,0 +1,36 @@
+package uuid
+
+import (
+	"crypto/md5"
+	"crypto/sha1"
+	"hash"
+)
+
+// A NamespaceGenerator allows consumers to generate UUIDs for a given namespace
+// and name.
+type NamespaceGenerator struct {
+	hashFactory func() hash.Hash
+	Namespace   UUID
+	Version     Version
+}
+
+// NewNamespaceGenerator creates a new UUID generator for the given namespace
+// and configuration.
+func NewNamespaceGenerator(namespace UUID, configuration Configuration) (g *NamespaceGenerator, err error) {
+	switch configuration.Version {
+	case 3:
+		return &NamespaceGenerator{md5.New, namespace, configuration.Version}, nil
+	case 5:
+		return &NamespaceGenerator{sha1.New, namespace, configuration.Version}, nil
+	}
+	return nil, errUnknownVersion
+}
+
+// Generate procues a new UUID that refelcts the given
+func (g *NamespaceGenerator) Generate(name []byte) UUID {
+	h := g.hashFactory()
+	data := append(g.Namespace, name...)
+	uuid := h.Sum(data)
+	applyFlags(uuid, g.Version)
+	return uuid
+}

--- a/namespace_generator_test.go
+++ b/namespace_generator_test.go
@@ -1,0 +1,83 @@
+package uuid
+
+import "testing"
+import "bytes"
+
+var aNamespaceUUID UUID = []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+var bNamespaceUUID UUID = []byte{16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1}
+
+func TestNewNamespaceGenerator(t *testing.T) {
+
+	unsupportedVersions := []Version{1, 2, 4}
+	supportedVersions := []Version{3, 5}
+
+	for _, version := range unsupportedVersions {
+		config := Configuration{Version: version}
+		g, err := NewNamespaceGenerator(aNamespaceUUID, config)
+
+		if err != errUnknownVersion {
+			t.Error("Expected NewNamespaceGenerator to return error with non namespaced versions")
+		}
+
+		if g != nil {
+			t.Error("Expected nil return value when error is returned")
+		}
+	}
+
+	for _, version := range supportedVersions {
+		config := Configuration{Version: version}
+		g, err := NewNamespaceGenerator(aNamespaceUUID, config)
+
+		if err != nil {
+			t.Error("Expected supported version to not return an error")
+		}
+
+		if g.hashFactory == nil {
+			t.Error("Did not expect null hashing factory")
+		}
+
+		if !bytes.Equal(aNamespaceUUID, g.Namespace) {
+			t.Error("Expected given namespace to be attributed to the generator")
+		}
+	}
+
+}
+
+func TestNamespacedGenerate(t *testing.T) {
+	testName := []byte("I love UUIDs")
+	secondName := []byte("I hate UUIDs")
+	versions := []Version{3, 5}
+
+	for _, version := range versions {
+		aGenerator, aErr := NewNamespaceGenerator(aNamespaceUUID, Configuration{Version: version})
+
+		if aErr != nil {
+			t.Error("Did not expect error when creating a new V3 Generator")
+		}
+
+		bGenerator, bErr := NewNamespaceGenerator(bNamespaceUUID, Configuration{Version: version})
+
+		if bErr != nil {
+			t.Error("Did not expect error when creating new Namespaced generator")
+		}
+
+		// Same name in a given namespace should return the same UUID
+		first := aGenerator.Generate(testName)
+		second := aGenerator.Generate(testName)
+
+		if !bytes.Equal(first, second) {
+			t.Error("Expected the same name in a single namespace to return same UUID")
+		}
+
+		// Differing names should produce differing UUIDs
+		third := aGenerator.Generate(secondName)
+		if bytes.Equal(first, third) {
+			t.Error("Expected differing names in single namespace to return differing UUIDs")
+		}
+
+		fourth := bGenerator.Generate(testName)
+		if bytes.Equal(first, fourth) {
+			t.Error("Expected same name in diferrent namespaces to return differing UUIDs")
+		}
+	}
+}


### PR DESCRIPTION
To accommodate version 3 and 5 UUIDs a namespaced generator is provided. It
allows consumers to create a new generator with a given namespace.